### PR TITLE
Remove AppKitCompatibilityDeclarations.h symlink

### DIFF
--- a/darling/include/wtf/mac/AppKitCompatibilityDeclarations.h
+++ b/darling/include/wtf/mac/AppKitCompatibilityDeclarations.h
@@ -1,1 +1,0 @@
-../../../../wtf/mac/AppKitCompatibilityDeclarations.h


### PR DESCRIPTION
It was removed upstream: https://github.com/darlinghq/darling-WTF/blob/e1426d734885874b167f90293e706edc85f046f5/ChangeLog#L15932-L15945